### PR TITLE
include config in languages definition

### DIFF
--- a/class-language-configuration.json
+++ b/class-language-configuration.json
@@ -1,0 +1,21 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  "brackets": [["{", "}"], ["(", ")"], ["[", "]"]],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [["{", "}"], ["(", ")"], ["[", "]"], ["\"", "\""]],
+  // symbols that that can be used to surround a selection
+  "surroundingPairs": [["{", "}"], ["(", ")"], ["\"", "\""], ["[", "]"]],
+  "indentationRules": {
+    "increaseIndentPattern": "^((Class|Client)?Method|Query|XData|Storage|Trigger)",
+    "decreaseIndentPattern": "^}"
+  },
+  "folding": {
+    "markers": {
+      "start": "^((Class|Client)?Method|Query|XData|Storage|Trigger)",
+      "end": "^}"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -205,7 +205,8 @@
         ],
         "extensions": [
           ".cls"
-        ]
+        ],
+        "configuration": "./class-language-configuration.json"
       },
       {
         "id": "objectscript-macros",


### PR DESCRIPTION
Hi, i have modified package.json to include configuration directive in objectscript-class definition.
Also i have created a copy of the language-definition-class.jsonc with the name class-language-definition.json.

This fixes the issue that if you toggle line comment in objectscript-class was using "#;" instead of "//".

Best Regards

Timo