### PR TITLE
first path implementation for recognizing js <script> tags

### DIFF
--- a/src/providers/ObjectScriptDiagnosticProvider.ts
+++ b/src/providers/ObjectScriptDiagnosticProvider.ts
@@ -95,9 +95,23 @@ export class ObjectScriptDiagnosticProvider {
     let inComment = false;
     let endingComma = false;
     let isCode = !isClass;
+    let jsScript = false;
     for (let i = 0; i < document.lineCount; i++) {
       const line = document.lineAt(i);
       const text = this.stripLineComments(line.text);
+
+      // it is important to check script tag context before ObjectScript comments
+      // since /* ... */ comments can also be used in JavaScript
+      if (text.match(/<script .*>/)) {
+        jsScript = true;
+      }
+
+      if (jsScript) {
+        if (text.match(/<\/script>/)) {
+          jsScript = false;
+        }
+        continue;
+      }
 
       if (text.match(/\/\*/)) {
         inComment = true;


### PR DESCRIPTION
Whenever we have <script> tags within objectscript embedded html (&html< ... >) lot's of js keywords were tried to be recognized as objectscript keywords. This led to highlighting most of javascript code with "Unrecognized command" warning.

This PR is only a quick workaround. Need more detailed implementation, since there are some cases when this implementation might not work perfectly.